### PR TITLE
Maintenance release 1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.3] - 2026-06-10
+
+### Changed
+
+- Maintenance release.
+- Updated Python dependencies: `cryptography`, `flask-reuploaded`, `sqlalchemy`, `weasyprint`.
+- Updated Javascript dependencies: `bootstrap-icons`, `alpinejs`.
+
 ## [1.10.2] - 2026-05-16
 
 ### Changed

--- a/coati_payroll/templates/auth/login.html
+++ b/coati_payroll/templates/auth/login.html
@@ -33,14 +33,14 @@ SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
 
         <!-- Bootstrap (mismo CDN que base) -->
         <link
-            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
             rel="stylesheet"
         />
 
         <!-- Bootstrap Icons -->
         <link
             rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+            href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css"
         />
 
         <!-- App styles -->

--- a/coati_payroll/templates/base.html
+++ b/coati_payroll/templates/base.html
@@ -27,13 +27,13 @@ SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- Bootstrap Icons -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.0/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css" />
 
     <!-- Custom styles -->
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
 
     <!-- Alpine.js -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js"></script>
 </head>
 
 <body>

--- a/coati_payroll/version.py
+++ b/coati_payroll/version.py
@@ -4,5 +4,5 @@
 Canonical version of coati_payroll.
 """
 
-# 2026-05-16
-__version__ = "1.10.2"
+# 2026-06-10
+__version__ = "1.10.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.18.4
 argon2-cffi==25.1.0
 babel==2.18.0
 configobj==5.0.9
-cryptography==48.0.0
+cryptography==48.0.1
 dramatiq[redis]==2.1.0
 email_validator==2.3.0
 flask==3.1.3
@@ -12,7 +12,7 @@ flask-caching==2.4.0
 flask-limiter==4.1.1
 flask-login==0.6.3
 flask-mail==0.10.0
-flask-reuploaded==1.5.0
+flask-reuploaded==1.6.0
 flask-session==0.8.0
 flask-sqlalchemy==3.1.1
 flask_weasyprint==1.2.0
@@ -23,8 +23,8 @@ orjson==3.11.9
 pg8000==1.31.5
 python-dateutil==2.9.0.post0
 python-ulid==3.1.0
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
 redis<7.5
 waitress==3.0.2
-weasyprint==68.1
+weasyprint==69.0
 wtforms==3.2.2


### PR DESCRIPTION
This PR performs a maintenance release for Coati Payroll.

Key changes:
1.  **Version Bump**: Updated `coati_payroll/version.py` to version `1.10.3`.
2.  **Changelog Update**: Added entry for `1.10.3` detailing the maintenance changes.
3.  **Python Dependency Upgrades**:
    - `cryptography` updated to `48.0.1`
    - `flask-reuploaded` updated to `1.6.0`
    - `sqlalchemy` updated to `2.0.50`
    - `weasyprint` updated to `69.0`
4.  **JavaScript Dependency Upgrades (CDN links)**:
    - `bootstrap-icons` updated to `1.13.1` (consistent across `base.html` and `login.html`)
    - `alpinejs` updated to `3.15.12`
    - `bootstrap` updated to `5.3.8` in `login.html` to match `base.html`
5.  **Quality Assurance**:
    - Ran the full validation stack via `dev/lint.sh` (Black, Ruff, Flake8, Pylint, Mypy, and Pytest).
    - All tests (1214 passed) and linting checks are clean.
    - Verified frontend rendering of the login page after upgrades.

---
*PR created automatically by Jules for task [14278589782856422918](https://jules.google.com/task/14278589782856422918) started by @williamjmorenor*